### PR TITLE
Fix the Floorp Welcome Page skipping entirely if you skip importing

### DIFF
--- a/floorp/browser/components/welcome/welcome.html
+++ b/floorp/browser/components/welcome/welcome.html
@@ -33,7 +33,7 @@
                 <h1 data-l10n-id="welcome-import-data" id="import-data-floorp-welcome-big-text" class="welcome-big-text"></h1>
                 <div data-l10n-id="welcome-import-data-description" id="import-data-discribe-floorp-text"></div>
                 <button data-l10n-id="welcome-import-data-button" id="import-data-floorp-welcome-button" class="go-next-page-button welcome-button primary"></button> 
-                <a data-l10n-id="welcome-import-data-skip" class="go-next-page-button" id="first-skip-setup-process" href="about:home"></a>
+                <a data-l10n-id="welcome-import-data-skip" class="go-next-page-button" id="first-skip-setup-process"></a>
               </div>
 
               <div id="second-select-template-box" class="welcome-setups">


### PR DESCRIPTION
### Check list
- [ ] Referenced all related issues
- [ ] Have tested the modifications

---

The JS already adds an actual function to this button in runtime, but due to this snippet of code removed in this PR unless you hold SHIFT pressing this button basically skips the entirety of the Welcome page. 